### PR TITLE
Loggers using @slf4j

### DIFF
--- a/src/main/java/net/engineeringdigest/journalApp/service/UserService.java
+++ b/src/main/java/net/engineeringdigest/journalApp/service/UserService.java
@@ -1,8 +1,11 @@
 package net.engineeringdigest.journalApp.service;
 
+import lombok.extern.slf4j.Slf4j;
 import net.engineeringdigest.journalApp.entity.User;
 import net.engineeringdigest.journalApp.repository.UserRepository;
 import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,6 +17,7 @@ import java.util.Optional;
 
 
 @Component
+@Slf4j
 public class UserService {
 
     @Autowired
@@ -21,10 +25,22 @@ public class UserService {
 
     private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    public void saveNewUser(User user) {
-        user.setPassword(passwordEncoder.encode(user.getPassword()));
-        user.setRoles(Arrays.asList("USER"));
-        userRepository.save(user);
+//    private static final Logger logger = LoggerFactory.getLogger(UserService.class);
+
+    public boolean saveNewUser(User user) {
+        try {
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+            user.setRoles(Arrays.asList("USER"));
+            userRepository.save(user);
+            return true;
+        } catch (Exception e) {
+            log.trace("Error occurred for user {}", user.getUserName());
+            log.debug("Error occurred for user {}", user.getUserName());
+            log.info("Error occurred for user {}", user.getUserName());
+            log.warn("Error occurred for user {}", user.getUserName());
+            log.error("Error occurred for user {}", user.getUserName());
+            return false;
+        }
     }
 
     public void saveAdmin(User user) {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+
+    <appender name="myConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{yy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="myFileAppender" class="ch.qos.logback.core.FileAppender">
+        <encoder>
+            <pattern>
+                %d{yy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n
+            </pattern>
+        </encoder>
+        <file>
+            journalApp.log
+        </file>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="myConsoleAppender"/>
+        <appender-ref ref="myFileAppender"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
Added logs using `slf4j` .

- We can create a custom logger using `slf4j`.  Here it's `logger`
- We can get a logger using the `@slf4j` annotation, it establishes a logger of the name `log`.

And there are 5 severity of logs. Here is the order

1. `TRACE`
2. `DEBUG`
3. `INFO`
4. `WARN`
5. `ERROR`

`INFO`, `WARN` and `ERROR` are printed by default, `TRACE` and `DEBUG` are achieved by modification in configuretions.