### PR TITLE
In Memory Cache | @PostConstruct | API URL in Atlas & accessing it using In-Memory cache with @PostConstruct Annotation

### DIFF
--- a/src/main/java/net/engineeringdigest/journalApp/Cache/AppCache.java
+++ b/src/main/java/net/engineeringdigest/journalApp/Cache/AppCache.java
@@ -1,0 +1,33 @@
+package net.engineeringdigest.journalApp.Cache;
+
+import net.engineeringdigest.journalApp.entity.ConfigJournalAppEntity;
+import net.engineeringdigest.journalApp.repository.ConfigJournalAppRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AppCache {
+
+    public enum keys {
+        weather_api;
+    }
+
+    @Autowired
+    private ConfigJournalAppRepository configJournalAppRepository;
+
+    public Map<String, String> APP_CACHE;
+
+    @PostConstruct
+    public void init() {
+        APP_CACHE = new HashMap<>();
+        List<ConfigJournalAppEntity> all = configJournalAppRepository.findAll();
+        for(ConfigJournalAppEntity configJournalAppEntity : all) {
+            APP_CACHE.put(configJournalAppEntity.getKey(), configJournalAppEntity.getValue());
+        }
+    }
+}

--- a/src/main/java/net/engineeringdigest/journalApp/constants/Placeholders.java
+++ b/src/main/java/net/engineeringdigest/journalApp/constants/Placeholders.java
@@ -1,0 +1,7 @@
+package net.engineeringdigest.journalApp.constants;
+
+public interface Placeholders {
+
+    String API_KEY = "<apiKey>";
+    String CITY = "<city>";
+}

--- a/src/main/java/net/engineeringdigest/journalApp/controller/AdminController.java
+++ b/src/main/java/net/engineeringdigest/journalApp/controller/AdminController.java
@@ -1,5 +1,6 @@
 package net.engineeringdigest.journalApp.controller;
 
+import net.engineeringdigest.journalApp.Cache.AppCache;
 import net.engineeringdigest.journalApp.entity.User;
 import net.engineeringdigest.journalApp.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,9 @@ public class AdminController {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private AppCache appCache;
+
     @GetMapping("/all-users")
     public ResponseEntity<?> getAllUsers() {
         List<User> all = userService.getAll();
@@ -28,5 +32,10 @@ public class AdminController {
     @PostMapping("/create-admin-user")
     public void createUser(@RequestBody User user) {
         userService.saveAdmin(user);
+    }
+
+    @GetMapping("/clear-app-cache")
+    public void clearAppCache() {
+        appCache.init();
     }
 }

--- a/src/main/java/net/engineeringdigest/journalApp/entity/ConfigJournalAppEntity.java
+++ b/src/main/java/net/engineeringdigest/journalApp/entity/ConfigJournalAppEntity.java
@@ -1,0 +1,14 @@
+package net.engineeringdigest.journalApp.entity;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "config_journal_app")
+@Data
+@NoArgsConstructor
+public class ConfigJournalAppEntity {
+
+    private String key;
+    private String value;
+}

--- a/src/main/java/net/engineeringdigest/journalApp/repository/ConfigJournalAppRepository.java
+++ b/src/main/java/net/engineeringdigest/journalApp/repository/ConfigJournalAppRepository.java
@@ -1,0 +1,9 @@
+package net.engineeringdigest.journalApp.repository;
+
+import net.engineeringdigest.journalApp.entity.ConfigJournalAppEntity;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ConfigJournalAppRepository extends MongoRepository<ConfigJournalAppEntity, ObjectId> {
+
+}

--- a/src/main/java/net/engineeringdigest/journalApp/service/WeatherService.java
+++ b/src/main/java/net/engineeringdigest/journalApp/service/WeatherService.java
@@ -1,6 +1,8 @@
 package net.engineeringdigest.journalApp.service;
 
+import net.engineeringdigest.journalApp.Cache.AppCache;
 import net.engineeringdigest.journalApp.api.response.WeatherResponse;
+import net.engineeringdigest.journalApp.constants.Placeholders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
@@ -14,14 +16,15 @@ public class WeatherService {
     @Value("${Weather_API_Key}")
     private String API_KEY;
 
-    private final String URL = "http://api.weatherstack.com/current?access_key=KEY&query=CITY";
-
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private AppCache appCache;
+
 
     public WeatherResponse getTemp(String city) {
-        String endPoint = URL.replace("CITY", city).replace("KEY", API_KEY);
+        String endPoint = appCache.APP_CACHE.get(AppCache.keys.weather_api.toString()).replace(Placeholders.CITY, city).replace(Placeholders.API_KEY, API_KEY);
         ResponseEntity<WeatherResponse> response = restTemplate.exchange(endPoint, HttpMethod.GET, null, WeatherResponse.class);
         WeatherResponse body = response.getBody();
         return body;


### PR DESCRIPTION
## Used @PostConstruct annotation for in-memory cache.
![image](https://github.com/user-attachments/assets/f327ee8c-ef76-4ceb-ab9a-3d84eecaac70)



### **1. Shifted API URL storage to MongoDB:**
   

> - API URLs are now stored as key-value pairs in a MongoDB collection for persistent storage.

###    **2. In-memory cache integration:**

>    - Cached the API URLs in an in-memory store to improve performance during API calls.
>    - Used the cached API URL to reduce repetitive database queries.

### **3. Repository and Interface additions:**

>    - Created a MongoRepository extension to interact with the MongoDB collection.
>    - Added an interface for storing variables related to key-value pairs.

### **4. Endpoint for cache clearing:**

> - Introduced an endpoint (init()) for clearing the application cache (AppCache).

### **5. Refactored API call logic:**

>  - Utilized variables and cached data for making efficient API calls.



## Atlas Collection

![image](https://github.com/user-attachments/assets/574061f2-8d99-4ddf-b832-8419edc27b56)
![image](https://github.com/user-attachments/assets/82ea5c7b-add5-4836-9b67-49f6c597b360)
